### PR TITLE
chore: attempt to discover the default branch and commit

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,9 +60,17 @@ jobs:
           npm run release -- --release-as "${{ github.event.release.tag_name }}"
           DEFAULT_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
           echo The default branch is "${DEFAULT_BRANCH}"
-          git remote set-head origin "${DEFAULT_BRANCH}"
+          if [ -z "${DEFAULT_BRANCH}" ]; then
+            DEFAULT_BRANCH='main'
+            lines=$(git branch -r | grep "${DEFAULT_BRANCH}" | wc -l | tr -d '[:space:]')
+            if [ "${lines}" == "0" ]; then
+              DEFAULT_BRANCH=master
+            fi
+          fi
+          echo The default branch was set to "${DEFAULT_BRANCH}"
           echo Debug follows
           git branch -r
           echo End debug
+          git remote set-head origin "${DEFAULT_BRANCH}" || echo Could not set the origin reference
           git push --follow-tags origin "${DEFAULT_BRANCH}"
 


### PR DESCRIPTION
# Story

I'm attempting to automate the changelog construction on release using the tools that each project has. However, there have been some steps needed to prepare to commit code to these repositories within the GitHub action. To date, the reference to the origin seems to be missing despite the simplistic-looking steps documented in [GitHub](https://github.com/actions/checkout#push-a-commit-using-the-built-in-token). Note the difference here is committing to another repository not the primary repository.

## Changes

1. Refactored the steps
2. Added debug info to help discover if the tools are going to be able to work

## Tests

This requires a new release as it is a triggered workflow, so testing happens organically when a new release is created.
